### PR TITLE
Minor fixes for playback

### DIFF
--- a/Divine Liturgy/Leitourgika and Axion Estin/Axion Estin 3 Al-Murr.byzx
+++ b/Divine Liturgy/Leitourgika and Axion Estin/Axion Estin 3 Al-Murr.byzx
@@ -67,7 +67,8 @@
     "textBoxDefaultColor": "#000000",
     "textBoxDefaultStrokeWidth": 0,
     "hyphenSpacing": 72,
-    "chrysanthineAccidentals": true
+    "chrysanthineAccidentals": true,
+    "noFthoraRestrictions": true
   },
   "headers": {
     "default": {

--- a/Divine Liturgy/Leitourgika and Axion Estin/Axion Estin Pl 2 Hatziathanasiou.byzx
+++ b/Divine Liturgy/Leitourgika and Axion Estin/Axion Estin Pl 2 Hatziathanasiou.byzx
@@ -651,7 +651,7 @@
         "elementType": "Note",
         "quantitativeNeume": "OligonPlusKentemata",
         "gorgonNeume": "Gorgon_Top",
-        "fthora": "HardChromaticPa_Bottom",
+        "fthora": "HardChromaticPa_Top",
         "chromaticFthoraNote": "Pa",
         "measureBarLeft": "MeasureBarTop",
         "tie": "YfenAbove",
@@ -659,6 +659,7 @@
         "isMelisma": true,
         "isMelismaStart": true,
         "isHyphen": true,
+        "fthoraOffsetY": 0.88,
         "tieOffsetY": -0.2
       },
       {
@@ -911,7 +912,7 @@
         "elementType": "Note",
         "quantitativeNeume": "OligonPlusKentemata",
         "gorgonNeume": "Gorgon_Top",
-        "fthora": "HardChromaticPa_Bottom",
+        "fthora": "HardChromaticPa_Top",
         "chromaticFthoraNote": "Pa",
         "measureBarLeft": "MeasureBarTop",
         "tie": "YfenAbove",
@@ -919,6 +920,7 @@
         "isMelisma": true,
         "isMelismaStart": true,
         "isHyphen": true,
+        "fthoraOffsetY": 0.88,
         "tieOffsetY": -0.2
       },
       {

--- a/Divine Liturgy/Leitourgika and Axion Estin/Axion Estin Pl 4 Nectarius.byzx
+++ b/Divine Liturgy/Leitourgika and Axion Estin/Axion Estin Pl 4 Nectarius.byzx
@@ -1256,7 +1256,7 @@
         "quantitativeNeume": "PetastiPlusHypsiliLeft",
         "timeNeume": "Klasma_Bottom",
         "fthora": "SoftChromaticPa_Top",
-        "chromaticFthoraNote": "Ga",
+        "chromaticFthoraNote": "Ke",
         "lyrics": "who"
       },
       {


### PR DESCRIPTION
**Divine Liturgy/Leitourgika and Axion Estin/Axion Estin 3 Al-Murr.byzx**
Added `"noFthoraRestrictions": true` because in the latest version of Neanes, the missing flag causes some of the spathi characters to disappear because they are "not allowed".

**Divine Liturgy/Leitourgika and Axion Estin/Axion Estin Pl 2 Hatziathanasiou.byzx**
Changed some hard chromatic fthores on PA from the `_Bottom` version to the `_Top`. When on bottom, the playback interprets the fthora as belonging to the kentimata instead of the oligon.

**Divine Liturgy/Leitourgika and Axion Estin/Axion Estin Pl 4 Nectarius.byzx**
Set the chromatic fthora note to KE for one of the phrases. It was previously on GA and I'm assuming KE was meant, but I could be mistaken.

<!--
  Welcome! It looks like you are creating a pull request. We think that is great.
  In order to be able to enforce the CC BY-NC-ND 4.0 license most effectively,
  this form is pre-populated with a Contributor License Agreement (CLA),
  which is required if you want to contribute to this repository.
-->

### Submitter checklist

- [x] By creating this pull request, I represent that I have the right to waive copyright and related rights to my contribution, I agree that all copyright and related rights to my contributions are waived, and I acknowledge that Basil Crow is assigned the copyright to use and modify my contribution under the CC BY-NC-ND 4.0 license in perpetuity.

<!--
  Put an x between [ ] to assign copyright to Basil Crow.
-->
